### PR TITLE
Fix a bug due to case sensitivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,36 @@
 # vim-nonmem
 A vim syntax highlighter for NONMEM models
 
+## Installation
+
+You can install using you favorite plugin manager. Instructions follow for [junegunn/vim-plug](https://github.com/junegunn/vim-plug).
+
+1. Install Vim-Plug, according to its instructions.
+2. Add the following text to your `vimrc`.
+```vim
+call plug#begin()
+  Plug 'UUPharmacometrics/vim-nonmem'
+call plug#end()
+```
+3. Restart Vim, and run the `:PlugInstall` statement to install your plugins.
+
+4. Be sure to symlink the syntax file into your syntax directory
+
+Vim
+```
+ln -s ~/.vim/plugged/vim-nonmem/nonmem.vim ~/.vim/syntax/nonmem.vim
+```
+
+NeoVim
+```
+ln -s ~/.config/nvim/plugged/vim-nonmem/nonmem.vim ~/.config/nvim/syntax/nonmem.vim
+```
+
 ## Activation
+
 
 Put the following in your .vimrc
 
 ```
-au BufNewFile,BufRead *.mod,*.ctl,*.lst set filetype=nm syntax=nm
+au BufNewFile,BufRead *.mod,*.ctl,*.lst,*.scm set filetype=nonmem syntax=nonmem
 ```

--- a/nonmem.vim
+++ b/nonmem.vim
@@ -1,5 +1,5 @@
 " Vim syntax file
-" Language:	NONMEM
+" Language:	nonmem
 " Maintainer:	Chayan Acharya <chayan.acharya@pharmetheus.com>
 
 if exists("b:current_syntax")
@@ -73,5 +73,5 @@ if version >= 508 || !exists("did_c_syn_inits")
   delcommand HiLink
 endif
 
-let b:current_syntax = "NONMEM"
+let b:current_syntax = "nonmem"
 

--- a/nonmem.vim
+++ b/nonmem.vim
@@ -1,6 +1,5 @@
 " Vim syntax file
 " Language:	nonmem
-" Maintainer:	Chayan Acharya <chayan.acharya@pharmetheus.com>
 
 if exists("b:current_syntax")
   finish


### PR DESCRIPTION
* (Neo)vim did not recognize the syntax file due to different cases (NONMEM vs nonmem), also in the README the instructions were to set the syntax and file to "nm" which was not recognized either.

* Updates  (removes) maintainer

* Adds installation instructions